### PR TITLE
Made electron easier to run

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({ width: 800, height: 600 });
 
   // and load the index.html of the app.
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/dist/index.html');
 
   // mainWindow.webContents.openDevTools();
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "npm run lint",
     "lint": "eslint app/**/*.js app/**/**/*.js gulpfile.js",
-    "format": "eslint --fix app/**/*.js app/**/**/*.js"
+    "format": "eslint --fix app/**/*.js app/**/**/*.js",
+    "electron": "gulp build && electron ."
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,7 @@
     "connect-history-api-fallback": "^1.1.0",
     "del": "^2.2.0",
     "electron-packager": "^5.2.0",
+    "electron-prebuilt": "^0.36.2",
     "eslint": "^1.10.3",
     "eslint-config-kellyirc": "3.1.0",
     "exorcist": "^0.4.0",


### PR DESCRIPTION
Forget what I said about all that copying files.

This opens the game in an electron app. Good for checking if the game works in electron.

```
npm run electron
```

This builds windows, linux, mac builds for x86 and x64 in the `/release` folder.

```
gulp build-standalone
```
